### PR TITLE
cluster_deploy_operator: new generic role to deploy an operator 

### DIFF
--- a/playbooks/cluster_deploy_operator.yml
+++ b/playbooks/cluster_deploy_operator.yml
@@ -1,0 +1,7 @@
+---
+- name: Deploy an Operator from OperatorHub
+  hosts: localhost
+  connection: local
+  gather_facts: true
+  roles:
+    - role: cluster_deploy_operator

--- a/roles/cluster_deploy_operator/defaults/main/config.yml
+++ b/roles/cluster_deploy_operator/defaults/main/config.yml
@@ -1,0 +1,20 @@
+---
+# Name of the catalog containing the operator.
+cluster_deploy_operator_catalog:
+# Name of the operator package manifest.
+cluster_deploy_operator_manifest_name:
+
+# Namespace in which the operator will be deployed.
+cluster_deploy_operator_namespace:
+cluster_deploy_operator_all_namespaces: False
+# Optional boolean flag to enable OpenShift namespace monitoring.
+cluster_deploy_operator_namespace_monitoring: False
+
+# Optional channel to deploy from. If unspecified, deploys the CSV's default channel.
+cluster_deploy_operator_channel:
+# Optional version to deploy. If unspecified, deploys the latest version available in the selected channel.
+cluster_deploy_operator_version:
+# Optional InstallPlan approval mode (Automatic or Manual). Default: Manual.
+cluster_deploy_operator_installplan_approval:
+# Optional flag to deploy the first example CR found in the CSV. Use 'True' as true value.
+cluster_deploy_operator_deploy_cr:

--- a/roles/cluster_deploy_operator/meta/main.yml
+++ b/roles/cluster_deploy_operator/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: check_deps

--- a/roles/cluster_deploy_operator/tasks/deploy_cr.yml
+++ b/roles/cluster_deploy_operator/tasks/deploy_cr.yml
@@ -1,0 +1,11 @@
+---
+- name: Get the CR of the operator from the CSV
+  shell:
+    set -o pipefail;
+    oc get "csv/{{ operator_csv_name }}"
+       -n "{{ cluster_deploy_operator_namespace }}"
+       -ojsonpath={.metadata.annotations."alm-examples"}
+    | jq .[0] > "{{ artifact_extra_logs_dir }}/003_operator_cr.json"
+
+- name: Create the operator CR
+  command: oc apply -f "{{ artifact_extra_logs_dir }}/003_operator_cr.json"

--- a/roles/cluster_deploy_operator/tasks/main.yml
+++ b/roles/cluster_deploy_operator/tasks/main.yml
@@ -1,0 +1,294 @@
+---
+- name: Check that cluster_deploy_operator_catalog is defined
+  fail: msg="Bailing out. This role requires 'cluster_deploy_operator_catalog'"
+  when: cluster_deploy_operator_catalog is undefined
+
+- name: Check that cluster_deploy_operator_manifest_name is defined
+  fail: msg="Bailing out. This role requires 'cluster_deploy_operator_manifest_name'"
+  when: cluster_deploy_operator_manifest_name is undefined
+
+- name: Check that cluster_deploy_operator_namespace is defined
+  fail: msg="Bailing out. This role requires 'cluster_deploy_operator_namespace'"
+  when: cluster_deploy_operator_namespace is undefined
+
+- name: Store deployment values (debug)
+  shell: |
+    cat <<EOF > {{ artifact_extra_logs_dir }}/deployment.txt
+    # Name of the catalog containing the operator.
+    cluster_deploy_operator_catalog: {{ cluster_deploy_operator_catalog }}
+    # Name of the operator package manifest.
+    cluster_deploy_operator_manifest_name: {{ cluster_deploy_operator_manifest_name }}
+
+    # Namespace in which the operator will be deployed.
+    cluster_deploy_operator_namespace: {{ cluster_deploy_operator_namespace }}
+    cluster_deploy_operator_all_namespaces: {{ cluster_deploy_operator_all_namespaces }}
+
+    # Optional channel to deploy from. If unspecified, deploys the CSV default channel.
+    cluster_deploy_operator_channel: {{ cluster_deploy_operator_channel }}
+    # Optional version to deploy. If unspecified, deploys the latest version available in the selected channel.
+    cluster_deploy_operator_version: {{ cluster_deploy_operator_version }}
+    # Optional InstallPlan approval mode (Automatic or Manual). Default: Manual.
+    cluster_deploy_operator_installplan_approval: {{ cluster_deploy_operator_installplan_approval }}
+    # Optional flag to deploy the first example CR found in the CSV. Use 'True' as true value.
+    cluster_deploy_operator_deploy_cr: {{ cluster_deploy_operator_deploy_cr }}
+    # Optional boolean flag to enable OpenShift namespace monitoring.
+    cluster_deploy_operator_namespace_monitoring: {{ cluster_deploy_operator_namespace_monitoring }}
+    EOF
+
+- name: Ensure the operator package is available
+  block:
+  - name: Ensure that the CatalogSource exists
+    command:
+      oc get CatalogSource/{{ cluster_deploy_operator_catalog }}
+         -n openshift-marketplace
+
+  - name: Capture the state of the CatalogSource (debug)
+    shell:
+      oc get -oyaml CatalogSource/{{ cluster_deploy_operator_catalog }}
+         -n openshift-marketplace
+         -oyaml
+      > {{ artifact_extra_logs_dir }}/catalogsource.yml
+    failed_when: false
+
+  - name: Ensure that the operator package manifest exists
+    command:
+      oc get packagemanifests/{{ cluster_deploy_operator_manifest_name }} -n openshift-marketplace
+    register: operator_package_available
+    until: operator_package_available.rc == 0
+    retries: 15
+    delay: 30
+
+  - name: Save the operator PackageManifest YAML (debug)
+    shell:
+      oc get packagemanifests/{{ cluster_deploy_operator_manifest_name }}
+         -n openshift-marketplace
+         -oyaml
+         > {{ artifact_extra_logs_dir }}/operator_packagemanifest.yml
+
+  - name: Store the operator PackageManifest JSON
+    shell:
+      oc get packagemanifests/{{ cluster_deploy_operator_manifest_name }}
+         -n openshift-marketplace
+         -ojson
+         > {{ artifact_extra_logs_dir }}/operator_packagemanifest.json
+
+  rescue:
+  - name: Capture the Catalog Operator logs (debug)
+    shell:
+      oc logs deployment.apps/catalog-operator
+         -n openshift-operator-lifecycle-manager
+         > {{ artifact_extra_logs_dir }}/catalog_operator.log
+    failed_when: false
+
+  - name: Indicate where the Catalog-operator logs have been saved
+    debug: msg="The logs of Catalog Operator have been saved in {{ artifact_extra_logs_dir }}/catalog_operator.log"
+
+  - name: Mark the failure as flake
+    shell:
+      echo "Failed because of the {{ cluster_deploy_operator_manifest_name }} PackageManifest not available"
+           > "{{ artifact_extra_logs_dir }}/FLAKE"
+
+  - name: Failed because the operator could not be found in the CatalogSource
+    fail: msg="Failed because the operator could not be found in the CatalogSource"
+
+- name: List the available channels if requested
+  when: cluster_deploy_operator_channel == "?"
+  block:
+
+  - name: List the channels available in the operator package manifest
+    command: |
+      jq '.status.channels[] | {
+            "channel": .name,
+            "version": .currentCSVDesc.version
+         }'
+         "{{ artifact_extra_logs_dir }}/operator_packagemanifest.json"
+    register: available_channels_cmd
+
+  - name: Get the default channel (debug)
+    command:
+      jq -r .status.defaultChannel "{{ artifact_extra_logs_dir }}/operator_packagemanifest.json"
+    register: default_channel_cmd
+
+  - name: Fail with the listing the available channels
+    fail:
+      msg: |
+        Available channels:
+        {{ available_channels_cmd.stdout }}
+        Default channel: {{ default_channel_cmd.stdout }}
+
+- name: Fetch the default channel name when none was requested
+  when: not cluster_deploy_operator_channel
+  block:
+  - name: Get the default channel of the operator
+    command:
+      jq -r
+         '.status.defaultChannel'
+         {{ artifact_extra_logs_dir }}/operator_packagemanifest.json
+    register: operator_channel_cmd
+    failed_when: not operator_channel_cmd.stdout
+
+- name: Store the channel name
+  block:
+  - name: Use the rescue block
+    when: cluster_deploy_operator_channel | default('', true) | length != 0
+    fail: msg="Use the rescue block"
+
+  - name: Store the channel name just computed
+    set_fact:
+      operator_channel: "{{ operator_channel_cmd.stdout }}"
+  rescue:
+  - name: Store the channel name passed as parameter
+    set_fact:
+      operator_channel: "{{ cluster_deploy_operator_channel }}"
+
+- name: "Get the version of the operator on channel '{{ cluster_deploy_operator_channel }}'"
+  when: cluster_deploy_operator_version | default('', true) | length == 0
+  command:
+    jq -r
+      '.status.channels[] | select(.name == "{{ operator_channel }}") | .currentCSV'
+      {{ artifact_extra_logs_dir }}/operator_packagemanifest.json
+  register: operator_csv_name_cmd
+  failed_when: not operator_csv_name_cmd.stdout
+
+- name: Fail if current CSV not found for the channel
+  fail: msg="Could not find the current CSV for the operator Channel '{{ operator_channel }}'"
+  when: cluster_deploy_operator_version | default('', true) | length == 0 and not operator_csv_name_cmd.stdout
+
+- name: Fetch the operator version and store its CSV name
+  block:
+  - name: Skip if the version was passed as a parameter '{{ cluster_deploy_operator_version }}'
+    when: cluster_deploy_operator_version | default('', true) | length > 0
+    fail: msg="Use the rescue block"
+
+  - name: Store the CSV version
+    set_fact:
+      operator_csv_name: "{{ operator_csv_name_cmd.stdout }}"
+
+  rescue:
+  - name: Store the CSV version from the parameter
+    set_fact:
+      operator_csv_name: "{{ cluster_deploy_operator_manifest_name }}.v{{ cluster_deploy_operator_version }}"
+
+- name: Store the CSV version
+  set_fact:
+    startingCSV: "{{ operator_csv_name }}"
+
+- name: Store the version of the Operator that will be installed
+  shell: echo "{{ startingCSV }}" > "{{ artifact_extra_logs_dir }}/operator_csv_name.txt"
+
+- name: "Create the Subscription"
+  debug: msg="startingCSV is {{ startingCSV }}"
+
+- name: Create the namespace, if it did not exist
+  when: not cluster_deploy_operator_all_namespaces | bool
+  block:
+  - name: Instantiate the Namespace template
+    template:
+      src: "{{ cluster_deploy_operator_res_ns }}"
+      dest: "{{ artifact_extra_logs_dir }}/000_namespace.yml"
+      mode: 0400
+
+  - name: Check if the namespace exists
+    command: oc get "ns/{{ cluster_deploy_operator_namespace }}"
+    failed_when: false
+    register: namespace_exists_cmd
+
+  - name: Create the namespace resource
+    when: namespace_exists_cmd.rc == 1
+    command:
+      oc create -f "{{ artifact_extra_logs_dir }}/000_namespace.yml"
+
+  - name: Mark the namespace for monitoring, if requested
+    when: cluster_deploy_operator_namespace_monitoring | bool
+    command:
+      oc label ns/{{ cluster_deploy_operator_namespace }} openshift.io/cluster-monitoring=true
+
+- name: Create the OperatorGroup for deploying in a dedicated namespace
+  when: not cluster_deploy_operator_all_namespaces | bool
+  block:
+  - name: Instantiate the OperatorGroup template
+    template:
+      src: "{{ cluster_deploy_operator_res_group }}"
+      dest: "{{ artifact_extra_logs_dir }}/001_operator_group.yml"
+      mode: 0400
+
+  - name: Instantiate the OperatorHub OperatorGroup resource
+    command: oc apply -f "{{ artifact_extra_logs_dir }}/001_operator_group.yml"
+
+- name: "Create the Subscription for {{ operator_csv_name }}"
+  template:
+    src: "{{ cluster_deploy_operator_res_sub }}"
+    dest: "{{ artifact_extra_logs_dir }}/002_sub.yml"
+    mode: 0400
+
+- name: Instantiate the Subscription
+  command: oc apply -f "{{ artifact_extra_logs_dir }}/002_sub.yml"
+
+- block:
+  - name: Find the operator InstallPlan
+    command:
+      oc get InstallPlan
+         -n "{{ cluster_deploy_operator_namespace }}"
+         -oname
+         -loperators.coreos.com/"{{ cluster_deploy_operator_manifest_name }}.{{ cluster_deploy_operator_namespace }}"
+    register: operator_installplan_name
+    until: operator_installplan_name.stdout != ""
+    retries: 20
+    delay: 30
+
+  - name: Approve the operator InstallPlan
+    when: cluster_deploy_operator_installplan_approval == "Manual"
+    command:
+      oc patch {{ operator_installplan_name.stdout }}
+         -n "{{ cluster_deploy_operator_namespace }}"
+         --type merge
+         --patch '{"spec":{"approved":true }}'
+
+  - name: Wait for the ClusterServiceVersion
+    command:
+      oc get ClusterServiceVersion/{{ operator_csv_name }}
+         -oname
+         -n "{{ cluster_deploy_operator_namespace }}"
+    register: operator_wait_csv
+    until: operator_wait_csv.stdout != ""
+    retries: 40
+    delay: 30
+
+  - name: Wait for the ClusterServiceVersion install to complete
+    command:
+      oc get ClusterServiceVersion/{{ operator_csv_name }}
+         -ojsonpath={.status.phase}
+         -n "{{ cluster_deploy_operator_namespace }}"
+    register: operator_csv_phase
+    until: operator_csv_phase.stdout != "Pending" and operator_csv_phase.stdout != "InstallReady" and operator_csv_phase.stdout != "Installing"
+    retries: 40
+    delay: 30
+
+  - name: Fail if the ClusterServiceVersion install did not succeeded
+    fail: msg="ClusterServiceVersion install not successful ({{ operator_csv_phase.stdout }})"
+    when: operator_csv_phase.stdout != "Succeeded"
+
+  always:
+  - name: Store the YAML of the operator CSV that was installed (debug)
+    shell:
+      oc get ClusterServiceVersion/{{ operator_csv_name }}
+         -oyaml
+          -n "{{ cluster_deploy_operator_namespace }}"
+          > {{ artifact_extra_logs_dir }}/operator_csv.yml
+  rescue:
+  - name: Capture the Catalog Operator logs (debug)
+    shell:
+      oc logs deployment.apps/catalog-operator
+         -n openshift-operator-lifecycle-manager
+         > {{ artifact_extra_logs_dir }}/catalog_operator.log
+    failed_when: false
+
+  - name: Indicate where the Catalog-operator logs have been saved
+    debug: msg="The logs of Catalog Operator have been saved in {{ artifact_extra_logs_dir }}/catalog_operator.log"
+
+  - name: Failed because the operator could not be installed from the CatalogSource
+    fail: msg="Failed because the operator could not be installed from the CatalogSource"
+
+- name: Deploy the operator CustomResource from its ClusterServiceVersion
+  include_tasks: deploy_cr.yml
+  when: cluster_deploy_operator_deploy_cr | bool

--- a/roles/cluster_deploy_operator/templates/namespace.yml.j2
+++ b/roles/cluster_deploy_operator/templates/namespace.yml.j2
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ cluster_deploy_operator_namespace }}
+{% if cluster_deploy_operator_namespace_monitoring | bool %}
+  label:
+    openshift.io/cluster-monitoring: true
+{% endif %}
+

--- a/roles/cluster_deploy_operator/templates/operator_group.yml.j2
+++ b/roles/cluster_deploy_operator/templates/operator_group.yml.j2
@@ -1,0 +1,9 @@
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: {{ cluster_deploy_operator_manifest_name }}-operator-group
+  namespace: {{ cluster_deploy_operator_namespace }}
+spec:
+  targetNamespaces:
+  - {{ cluster_deploy_operator_namespace }}

--- a/roles/cluster_deploy_operator/templates/subscription.yml.j2
+++ b/roles/cluster_deploy_operator/templates/subscription.yml.j2
@@ -1,0 +1,13 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: gpu-operator-certified
+  namespace: "{{ cluster_deploy_operator_namespace }}"
+spec:
+  channel: "{{ cluster_deploy_operator_channel }}"
+  installPlanApproval: "{{ cluster_deploy_operator_installplan_approval }}"
+  name: "{{ cluster_deploy_operator_manifest_name }}"
+  source: "{{ cluster_deploy_operator_catalog }}"
+  sourceNamespace: openshift-marketplace
+  startingCSV: "{{ startingCSV }}"

--- a/roles/cluster_deploy_operator/vars/main/resources.yml
+++ b/roles/cluster_deploy_operator/vars/main/resources.yml
@@ -1,0 +1,4 @@
+---
+cluster_deploy_operator_res_ns: roles/cluster_deploy_operator/templates/namespace.yml.j2
+cluster_deploy_operator_res_group: roles/cluster_deploy_operator/templates/operator_group.yml.j2
+cluster_deploy_operator_res_sub: roles/cluster_deploy_operator/templates/subscription.yml.j2

--- a/roles/gpu_operator_bundle_from_commit/templates/build_validator.yml.j2
+++ b/roles/gpu_operator_bundle_from_commit/templates/build_validator.yml.j2
@@ -28,7 +28,7 @@ spec:
         - name: VERSION
           value: v0.1.0
         - name: GOLANG_VERSION
-          value: '1.15'
+          value: '1.17'
         - name: CUDA_SAMPLE_IMAGE
           value: nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda11.2.1-ubi8
         - name: CUDA_IMAGE

--- a/roles/gpu_operator_bundle_from_commit/templates/operator_image_builder_pod.yml.j2
+++ b/roles/gpu_operator_bundle_from_commit/templates/operator_image_builder_pod.yml.j2
@@ -23,7 +23,7 @@ spec:
       - name: OPERATOR_IMAGE_NAME
         value: "{{ operator_image_name }}"
       - name: BUILDER_FROM_IMAGE
-        value: "quay.io/openshift-psap/golang:1.15" # avoid using docker.io and its quotas...
+        value: "quay.io/openshift-psap/golang:1.17" # avoid using docker.io and its quotas...
     volumeMounts:
     - mountPath: /mnt/helper/run_operator_image_builder.sh
       name: operator-image-builder-script

--- a/toolbox/gpu_operator.py
+++ b/toolbox/gpu_operator.py
@@ -50,10 +50,20 @@ class GPUOperator:
             version: Optional version to deploy. If unspecified, deploys the latest version available in the selected channel. Run the toolbox gpu_operator list_version_from_operator_hub subcommand to see the available versions.
             installPlan: Optional InstallPlan approval mode (Automatic or Manual [default])
         """
-        opts = {"gpu_operator_target_namespace": namespace}
+
+        opts = {
+            "cluster_deploy_operator_catalog": "certified-operators",
+            "cluster_deploy_operator_manifest_name": "gpu-operator-certified",
+
+            "cluster_deploy_operator_namespace": namespace,
+            "cluster_deploy_operator_all_namespaces": namespace == "openshift-operators",
+
+            "cluster_deploy_operator_deploy_cr": True,
+            "cluster_deploy_operator_namespace_monitoring": True,
+        }
 
         if channel is not None:
-            opts["gpu_operator_operatorhub_channel"] = channel
+            opts["cluster_deploy_operator_channel"] = channel
             print(
                 f"Deploying the GPU Operator from OperatorHub using channel '{channel}'."
             )
@@ -63,12 +73,12 @@ class GPUOperator:
                 print("Version may only be specified if --channel is specified")
                 sys.exit(1)
 
-            opts["gpu_operator_operatorhub_version"] = version
+            opts["cluster_deploy_operator_version"] = version
             print(
                 f"Deploying the GPU Operator from OperatorHub using version '{version}'."
             )
 
-        opts["gpu_operator_installplan_approval"] = installPlan
+        opts["cluster_deploy_operator_installplan_approval"] = installPlan
         if installPlan not in ("Manual", "Automatic"):
             print(
                 f"InstallPlan can only be Manual or Automatic. Received '{installPlan}'."
@@ -80,7 +90,7 @@ class GPUOperator:
         )
 
         print("Deploying the GPU Operator from OperatorHub.")
-        return PlaybookRun("gpu_operator_deploy_from_operatorhub", opts)
+        return PlaybookRun("cluster_deploy_operator", opts)
 
     @staticmethod
     def run_gpu_burn(runtime=None):

--- a/toolbox/nfd_operator.py
+++ b/toolbox/nfd_operator.py
@@ -33,12 +33,17 @@ class NFDOperator:
         Args:
             The operator hub channel to deploy. e.g. 4.7
         """
-        opts = {}
+        opts = {
+            "cluster_deploy_operator_catalog": "redhat-operators",
+            "cluster_deploy_operator_manifest_name": "nfd",
+            "cluster_deploy_operator_namespace": "openshift-nfd",
+            "cluster_deploy_operator_deploy_cr": True,
+        }
 
         if channel is not None:
-            opts["nfd_channel"] = channel
+            opts["cluster_deploy_operator_channel"] = channel
 
-        return PlaybookRun("nfd_operator_deploy_from_operatorhub", opts)
+        return PlaybookRun("cluster_deploy_operator", opts)
 
     @staticmethod
     def undeploy_from_operatorhub():


### PR DESCRIPTION
This PR creates a new toolbox command, which allows deploying any operator from OperatorHub, by specifying its PackageManifest name and SourceCatalog name:
```
./run_toolbox.py cluster deploy_operator
```
eg:
```
 ./run_toolbox.py cluster deploy_operator certified-operators gpu-operator-certified openshift-operators --channel=v1.8 --version=1.8.2 --deploy-cr=true --ns-monitoring=true
```
I also rewrote the GPU Operator and NFD deployment entrypoints to transparently use these roles, instead of `gpu_operator_deploy_from_operatorhub` and `nfd_operator_deploy_from_operatorhub`.

I don't see any reason to keep these last two roles, but I didn't delete them yet...