### PR TITLE
cluster_deploy_operator: deploy the CR inside 'cluster_deploy_operator_namespace'

### DIFF
--- a/roles/cluster_deploy_operator/tasks/deploy_cr.yml
+++ b/roles/cluster_deploy_operator/tasks/deploy_cr.yml
@@ -8,4 +8,7 @@
     | jq .[0] > "{{ artifact_extra_logs_dir }}/003_operator_cr.json"
 
 - name: Create the operator CR
-  command: oc apply -f "{{ artifact_extra_logs_dir }}/003_operator_cr.json"
+  command:
+    oc apply
+       -f "{{ artifact_extra_logs_dir }}/003_operator_cr.json"
+       -n "{{ cluster_deploy_operator_namespace }}"


### PR DESCRIPTION
Otherwise the deployment will fail in the CI if	the CR doesn't specify any namespace, [eg, when deploying NFD on 4.6](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-rh-ecosystem-edge-ci-artifacts-master-4.6-gpu-operator-e2e-170/1486489480759087104/artifacts/gpu-operator-e2e-170/nightly/artifacts/005__nfd_operator__deploy_from_operatorhub/_ansible.log):
      	
```	
{	
  "apiVersion":	"nfd.openshift.io/v1alpha1",                        				
  "kind": "NodeFeatureDiscovery",
  "metadata": {
    "name": "nfd-master-server"
  },  	
  "spec": {                                                   					
    "namespace": "openshift-nfd"
  }
}                                                                                                     	
```

```
----- FAILED ----
msg: non-zero return code

<command> oc apply -f /logs/artifacts/005__nfd_operator__deploy_from_operatorhub/003_operator_cr.json

<stderr> Error	from server (NotFound):	error when creating "/logs/artifacts/005__nfd_operator__deploy_from_operatorhub/003_operator_cr.json": namespaces "ci-op-m6r2z9t1" not found
----- FAILED ----                     	
```     