### PR TITLE
testing: prow/gpu-operator.sh: manually create namespace for v1.{4,5,6}

### DIFF
--- a/testing/prow/gpu-operator.sh
+++ b/testing/prow/gpu-operator.sh
@@ -391,6 +391,11 @@ test_operatorhub() {
 
     if [ "${1:-}" ]; then
         OPERATOR_VERSION="--version=$1"
+        if [[ "$1" == "1.4"* || "$1" == "1.5"* || "$1" == "1.6"* ]]; then
+            # these versions of the GPU Operator require the namespace
+            # to be manually created.
+            oc new-project gpu-operator-resources || true
+        fi
     fi
     shift || true
     if [ "${1:-}" ]; then


### PR DESCRIPTION
Following the merge of https://github.com/rh-ecosystem-edge/ci-artifacts/pull/9/commits, testing of the GPU Operator is broken on 4.6. This PR should fix the last broken bits, by manually creating the `gpu-operator-namespace`, as required on old (<1.7) versions of the operator.

```
test-path: prow gpu-operator test_operatorhub 1.4.0 stable
test-path: prow gpu-operator cleanup_cluster
test-path: prow gpu-operator test_operatorhub 1.5.2 stable
test-path: prow gpu-operator cleanup_cluster
test-path: prow gpu-operator test_operatorhub 1.6.2 stable
```