### PR TITLE
Updated operator image builder script

### DIFF
--- a/roles/gpu_operator_bundle_from_commit/files/operator_image_builder_script.yml
+++ b/roles/gpu_operator_bundle_from_commit/files/operator_image_builder_script.yml
@@ -20,18 +20,21 @@ data:
 
     git show --quiet
 
+    IMAGE_NAME=$(echo $OPERATOR_IMAGE_NAME | sed 's/\(.*\):/\1 /' | awk '{print $1}')
+    IMAGE_TAG=$(echo $OPERATOR_IMAGE_NAME | sed 's/\(.*\):/\1 /' | awk '{print $2}')
+
     # if provided, use custom 'FROM ... as builder' image by setting BUILDER_IMAGE variable
     # avoid docker.io quotas by setting CUDA_IMAGE
     # The docker-image generates an image OUT_IMAGE (based on OPERATOR_IMAGE_NAME)
     make docker-image \
       VERSION=$(git rev-parse --short HEAD) \
       DOCKER=podman \
-      OUT_IMAGE=${OPERATOR_IMAGE_NAME} \
+      IMAGE_NAME=${IMAGE_NAME} \
+      IMAGE_TAG=${IMAGE_TAG} \
       CUDA_IMAGE=nvcr.io/nvidia/cuda \
       ${BUILDER_FROM_IMAGE:+BUILDER_IMAGE=${BUILDER_FROM_IMAGE}}
 
     # push the image locally
-
     (echo "{ \"auths\": " ; cat /var/run/secrets/openshift.io/push/.dockercfg ; echo "}") > /tmp/.dockercfg
     AUTH="--tls-verify=false --authfile /tmp/.dockercfg"
 


### PR DESCRIPTION
NVIDIA [introduced some breaking changes](https://gitlab.com/nvidia/kubernetes/gpu-operator/-/merge_requests/396) to the gpu operator makefile. This was done to support multi-arch image build.

This PR is adopting the new params passed to the make target.

Tested on 4.6 4.9 4.10