### PR TITLE
New role `ocm_install_addon`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -882,4 +882,37 @@ sro
     NOTES
         You can also use flags syntax for POSITIONAL ARGUMENTS
 
+ 
+OCM addons
+""""""""""
 
+``./run_toolbox.py ocm_addon install``
+
+.. code-block:: text
+
+    NAME
+        run_toolbox.py ocm_addon install - Installs an OCM addon
+    
+    SYNOPSIS
+        run_toolbox.py ocm_addon install OCM_REFRESH_TOKEN OCM_CLUSTER_ID OCM_URL OCM_ADDON_ID <flags>
+    
+    DESCRIPTION
+        Installs an OCM addon
+    
+    POSITIONAL ARGUMENTS
+        OCM_REFRESH_TOKEN
+            For OCM login auth
+        OCM_CLUSTER_ID
+            Cluster ID from OCM's POV
+        OCM_URL
+            Used to determine environment
+        OCM_ADDON_ID
+            the addon id to install. (such as `managed-odh`, `gpu-operator-certified-addon` etc.)
+    
+    FLAGS
+        --wait_for_ready_state=WAIT_FOR_READY_STATE
+            Default: False
+            Optional. If true will cause the role to wait until addon reports ready state. (Can time out)
+    
+    NOTES
+        You can also use flags syntax for POSITIONAL ARGUMENTS

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -26,6 +26,12 @@ ARG OCP_CLI_VERSION=latest
 ARG OCP_CLI_URL=https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/${OCP_CLI_VERSION}/openshift-client-linux.tar.gz
 RUN curl ${OCP_CLI_URL} | tar xfz - -C /usr/local/bin oc
 
+# Install dependencies: `ocm`
+ARG OCM_CLI_VERSION=v0.1.60
+ARG OCM_CLI_URL=https://github.com/openshift-online/ocm-cli/releases/download/${OCM_CLI_VERSION}/ocm-linux-amd64
+RUN curl -L ${OCM_CLI_URL} --output /usr/local/bin/ocm
+RUN chmod +x /usr/local/bin/ocm
+
 # Install dependencies: `helm`
 ARG HELM_VERSION=v3.5.1
 ARG HELM_URL=https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz

--- a/playbooks/ocm_install_addon.yml
+++ b/playbooks/ocm_install_addon.yml
@@ -1,0 +1,7 @@
+---
+- name: Install OCM addon
+  hosts: localhost
+  connection: local
+  gather_facts: true
+  roles:
+    - role: ocm_install_addon

--- a/roles/ocm_install_addon/files/ocm_addon_template.json.j2
+++ b/roles/ocm_install_addon/files/ocm_addon_template.json.j2
@@ -1,0 +1,5 @@
+{
+  "addon": {
+    "id": "{{ ocm_addon_id  }}"
+  }
+}

--- a/roles/ocm_install_addon/tasks/main.yml
+++ b/roles/ocm_install_addon/tasks/main.yml
@@ -1,0 +1,118 @@
+---
+- name: Fail if ocm_refresh_token is undefined
+  fail: msg="Bailing out. This play requires ocm_refresh_token"
+  when: ocm_refresh_token is undefined
+
+- name: Fail if ocm_addon_id is undefined
+  fail: msg="Bailing out. This play requires 'ocm_addon_id'"
+  when: ocm_addon_id is undefined
+
+- name: Fail if ocm_url is undefined
+  fail: msg="Bailing out. This play requires 'ocm_url'"
+  when: ocm_url is undefined
+
+- name: Fail if ocm_cluster_id is undefined
+  fail: msg="Bailing out. This play requires 'ocm_cluster_id'"
+  when: ocm_cluster_id is undefined
+
+- name: Debug cluster and url (env)
+  debug:
+    msg: "ocm_cluster_id: {{ ocm_cluster_id  }}, ocm_url: {{ ocm_url }}"
+
+- name: ocm addon id
+  debug:
+    msg: "ocm addon id to install: {{ ocm_addon_id  }}"
+
+- name: Check if ocm is available
+  command: ocm version
+  register: ocm_version
+  changed_when: false
+  failed_when: false
+
+- name: Fail if ocm is not available
+  fail: msg="ocm version command returned with a non 0 code"
+  when: ocm_version.rc|int != 0
+
+- name: Login to ocm
+  command: "ocm login --token={{ ocm_refresh_token }} --url={{ ocm_url }}"
+  no_log: true
+  register: ocm_login_cmd
+  changed_when: false
+
+- name: Check ocm whoami
+  command: ocm whoami
+  register: ocm_whoami
+  changed_when: false
+  failed_when: false
+
+- name: Fail if ocm is not logged in
+  fail: msg="ocm whoami failed with return code {{ ocm_whoami.rc  }}"
+  when: ocm_whoami.rc|int != 0
+
+- name: ocm whoami
+  debug:
+    msg: "ocm whoami: {{ ocm_whoami.stdout  }}"
+  changed_when: false
+  failed_when: false
+
+- name: Check if addon is already installed
+  shell: 
+    cmd: "ocm get /api/clusters_mgmt/v1/clusters/{{ ocm_cluster_id }}/addons/{{ ocm_addon_id  }} 2>&1 | jq -r '.kind'"
+  register: ocm_addon_precheck
+  failed_when: false
+  changed_when: false
+
+- name: Set addon current state
+  set_fact:
+    addon_install_needed: "{{ ocm_addon_precheck.stdout == 'Error' }}"
+  changed_when: false
+
+- name: Install needed
+  debug: 
+    msg: "Install needed: {{ addon_install_needed  }}"
+
+- name: Create ocm addon install payload
+  template:
+    src: roles/ocm_install_addon/files/ocm_addon_template.json.j2
+    dest: /tmp/addon_{{ ocm_addon_id  }}.json
+    mode: '0777'
+  changed_when: false
+  when: addon_install_needed
+
+- name: "Install addon {{ ocm_addon_id  }} via ocm"
+  shell: 
+    cmd: "ocm post /api/clusters_mgmt/v1/clusters/{{ ocm_cluster_id  }}/addons --body=/tmp/addon_{{ ocm_addon_id  }}.json 2>&1 | jq -r '.kind'"
+  register: addon_install_command
+  failed_when: false
+  when: addon_install_needed
+
+- name: Fail if response kind is not AddOnInstallation
+  fail: 
+    msg: "response kind: {{ addon_install_command.stdout }}"
+  when: 
+    - addon_install_command is defined
+    - addon_install_command.stdout is defined
+    - addon_install_command.stdout != 'AddOnInstallation'
+
+- name: Debug wait_for_ready_state
+  debug: msg="Wait for ready state={{ wait_for_ready_state }}"
+
+- name: Poll addon state until reached desired state
+  shell:
+    cmd: "ocm get /api/clusters_mgmt/v1/clusters/{{ ocm_cluster_id }}/addons/{{ ocm_addon_id  }} 2>&1 | jq -r '.state'"
+  register: addon_state_result
+  changed_when: false
+  retries: 6
+  delay: 600
+  until: | 
+    (addon_state_result.stdout == 'deleting') or 
+    (addon_state_result.stdout == 'failed') or
+    (addon_state_result.stdout == 'installing' and not wait_for_ready_state) or
+    (addon_state_result.stdout == 'ready')
+  failed_when: |
+    (addon_state_result.stdout == 'deleting') or
+    (addon_state_result.stdout == 'failed') or
+    (wait_for_ready_state and addon_state_result.stdout != 'ready')
+
+- name: Polling end debug info
+  debug: msg="AddinId={{ ocm_addon_id }}, Wait for ready state={{ wait_for_ready_state }}, Current addon state={{ addon_state_result.stdout }}"

--- a/roles/ocm_install_addon/vars/main.yaml
+++ b/roles/ocm_install_addon/vars/main.yaml
@@ -1,0 +1,1 @@
+wait_for_ready_state: false

--- a/run_toolbox.py
+++ b/run_toolbox.py
@@ -17,6 +17,7 @@ from toolbox.local_ci import LocalCI
 from toolbox.repo import Repo
 from toolbox.special_resource_operator import SpecialResourceOperator
 from toolbox.benchmarking import Benchmarking
+from toolbox.ocm_addon import OCMAddon
 
 
 class Toolbox:
@@ -40,6 +41,7 @@ class Toolbox:
         self.local_ci = LocalCI
         self.sro = SpecialResourceOperator
         self.benchmarking = Benchmarking
+        self.ocm_addon = OCMAddon
 
 def main(no_exit=False):
     # Print help rather than opening a pager

--- a/toolbox/ocm_addon.py
+++ b/toolbox/ocm_addon.py
@@ -1,0 +1,31 @@
+import sys
+import secrets
+
+from toolbox._common import PlaybookRun
+
+
+class OCMAddon:
+    """
+    Commands for managing OCM addons
+    """
+    @staticmethod
+    def install(ocm_refresh_token, ocm_cluster_id, ocm_url, ocm_addon_id, wait_for_ready_state=False):
+        """
+        Installs an OCM addon
+
+        Args:
+            ocm_refresh_token: For OCM login auth
+            ocm_cluster_id: Cluster ID from OCM's POV
+            ocm_url: Used to determine environment
+            ocm_addon_id: the addon id to install. (such as `managed-odh`, `gpu-operator-certified-addon` etc.)
+            wait_for_ready_state: Optional. If true will cause the role to wait until addon reports ready state. (Can time out)
+        """
+        opt = {
+            "ocm_addon_id": ocm_addon_id,
+            "ocm_cluster_id": ocm_cluster_id,
+            "ocm_url": ocm_url,
+            "ocm_refresh_token": ocm_refresh_token,
+            "wait_for_ready_state": wait_for_ready_state,
+        }
+        return PlaybookRun("ocm_install_addon", opt)
+


### PR DESCRIPTION
this new role allows you to use OCM and install an addon, with an option to wait until `ready` state.

This new role is used for the osde2e test.
 - Install RHODS and wait until its ready (1 hour timeout)
 - Install GPU AddOn - Dont wait until ready.

Role was added to the toolbox as well.

```
NAME
    run_toolbox.py ocm_addon install - Installs an OCM addon

SYNOPSIS
    run_toolbox.py ocm_addon install OCM_REFRESH_TOKEN OCM_CLUSTER_ID OCM_URL OCM_ADDON_ID <flags>

DESCRIPTION
    Installs an OCM addon

POSITIONAL ARGUMENTS
    OCM_REFRESH_TOKEN
        For OCM login auth
    OCM_CLUSTER_ID
        Cluster ID from OCM's POV
    OCM_URL
        Used to determine environment
    OCM_ADDON_ID
        the addon id to install. (such as `managed-odh`, `gpu-operator-certified-addon` etc.)

FLAGS
    --wait_for_ready_state=WAIT_FOR_READY_STATE
        Default: False
        Optional. If true will cause the role to wait until addon reports ready state. (Can time out)

NOTES
    You can also use flags syntax for POSITIONAL ARGUMENTS
```

/cc @kpouget
/cc @fabiendupont 