### PR TITLE
cluster_deploy_operator: fix typo in the subscription name

### DIFF
--- a/roles/cluster_deploy_operator/templates/subscription.yml.j2
+++ b/roles/cluster_deploy_operator/templates/subscription.yml.j2
@@ -2,7 +2,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: gpu-operator-certified
+  name: "{{ cluster_deploy_operator_manifest_name }}"
   namespace: "{{ cluster_deploy_operator_namespace }}"
 spec:
   channel: "{{ cluster_deploy_operator_channel }}"


### PR DESCRIPTION
Note that this typo did not affect the good behavior of the role, as
long as no two operators were deployed in the same namespace.

/cc @sagidayan 