### PR TITLE
Poll addon state until installed or ready

### DIFF
--- a/roles/ocm_install_addon/tasks/main.yml
+++ b/roles/ocm_install_addon/tasks/main.yml
@@ -105,8 +105,6 @@
   retries: 6
   delay: 600
   until: | 
-    (addon_state_result.stdout == 'deleting') or 
-    (addon_state_result.stdout == 'failed') or
     (addon_state_result.stdout == 'installing' and not wait_for_ready_state) or
     (addon_state_result.stdout == 'ready')
   failed_when: |


### PR DESCRIPTION
If state is `failed` continue polling.

This is due to some strange results in CI. the state is `failed` but after a while it becomes `ready`.