### PR TITLE
Remove '&' char from JUnit output

### DIFF
--- a/testing/osde2e/gpu-addon.sh
+++ b/testing/osde2e/gpu-addon.sh
@@ -79,8 +79,10 @@ function finalize_junit() {
 
     echo "====== Finalizing JUnit report"
 
-    # Replace '<' and '>' from output so it won't break the XML
+    # Replace '<' and '>' with '**' in output so it won't break the XML
     sed  -i 's/[<>]/\*\*/g' $OUTPUT_FILE
+    # Replace '&' with '@' output so it won't break the XML
+    sed  -i 's/[&]/@/g' $OUTPUT_FILE
     set -x
     RUNTIME="$(cat ${RUNTIME_FILE} | egrep -o '[0-9:.]+elapsed' | sed 's/elapsed//')"
 


### PR DESCRIPTION
This PR fixes XML parse CI error due to '&' char in output