### PR TITLE
testing/prow/gpu-operator.sh: use channel instead of version to detect v1.7 v1.8

### DIFF
--- a/testing/prow/gpu-operator.sh
+++ b/testing/prow/gpu-operator.sh
@@ -443,11 +443,12 @@ test_operatorhub() {
     shift || true
     if [[ "${1:-}" ]]; then
         OPERATOR_CHANNEL="--channel=$1"
+        operator_channel="$1"
         if [[ "$operator_version" == "1.4"* \
            || "$operator_version" == "1.5"* \
            || "$operator_version" == "1.6"* \
-           || "$operator_version" == "1.7"* \
-           || "$operator_version" == "1.8"* ]];
+           || "$operator_channel" == "v1.7" \
+           || "$operator_channel" == "v1.8" ]];
         then
             # these versions of the GPU Operator can only be installed
             # in "all the namespaces"


### PR DESCRIPTION
Without this fix, v1.7 and v1.8 `latest` versions get deployed in `nvidia-gpu-operator` namespace, as it happened in this [rehearsal](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_release/27517/rehearse-27517-pull-ci-rh-ecosystem-edge-ci-artifacts-master-4.6-nvidia-gpu-operator-e2e/1511636835674099712/artifacts/nvidia-gpu-operator-e2e/presubmit-operatorhub/artifacts/009__gpu_operator__deploy_from_operatorhub/001_operator_group.yml) of https://github.com/openshift/release/pull/27517
