### PR TITLE
OSDE2E addon test tweaks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -910,6 +910,9 @@ OCM addons
             the addon id to install. (such as `managed-odh`, `gpu-operator-certified-addon` etc.)
     
     FLAGS
+        --ocm_addon_params=OCM_ADDON_PARAMS
+            Default: []
+            Optional. list of dicts i.e [{"id":"something","value":"something"},{"id":"something_else","value":"we-get-it"}]
         --wait_for_ready_state=WAIT_FOR_READY_STATE
             Default: False
             Optional. If true will cause the role to wait until addon reports ready state. (Can time out)

--- a/roles/ocm_install_addon/files/ocm_addon_template.json.j2
+++ b/roles/ocm_install_addon/files/ocm_addon_template.json.j2
@@ -1,5 +1,8 @@
 {
   "addon": {
     "id": "{{ ocm_addon_id  }}"
+  },
+  "parameters": {
+    "items": {{ ocm_addon_params }}
   }
 }

--- a/roles/ocm_install_addon/tasks/main.yml
+++ b/roles/ocm_install_addon/tasks/main.yml
@@ -79,6 +79,13 @@
   changed_when: false
   when: addon_install_needed
 
+- name: Replace single quote with double in install payload
+  when: addon_install_needed
+  replace:
+    path: "/tmp/addon_{{ com_addon_id }}.json"
+    regexp: "'"
+    replace: '"'
+
 - name: "Install addon {{ ocm_addon_id  }} via ocm"
   shell: 
     cmd: "ocm post /api/clusters_mgmt/v1/clusters/{{ ocm_cluster_id  }}/addons --body=/tmp/addon_{{ ocm_addon_id  }}.json 2>&1 | jq -r '.kind'"

--- a/roles/ocm_install_addon/vars/main.yaml
+++ b/roles/ocm_install_addon/vars/main.yaml
@@ -1,1 +1,2 @@
 wait_for_ready_state: false
+ocm_addon_params: []

--- a/toolbox/ocm_addon.py
+++ b/toolbox/ocm_addon.py
@@ -9,7 +9,7 @@ class OCMAddon:
     Commands for managing OCM addons
     """
     @staticmethod
-    def install(ocm_refresh_token, ocm_cluster_id, ocm_url, ocm_addon_id, wait_for_ready_state=False):
+    def install(ocm_refresh_token, ocm_cluster_id, ocm_url, ocm_addon_id, ocm_addon_params=[], wait_for_ready_state=False):
         """
         Installs an OCM addon
 
@@ -18,13 +18,16 @@ class OCMAddon:
             ocm_cluster_id: Cluster ID from OCM's POV
             ocm_url: Used to determine environment
             ocm_addon_id: the addon id to install. (such as `managed-odh`, `gpu-operator-certified-addon` etc.)
+            ocm_addon_params: Optional. list of dicts i.e [{"id":"something","value":"something"},{"id":"something_else","value":"we-get-it"}]
             wait_for_ready_state: Optional. If true will cause the role to wait until addon reports ready state. (Can time out)
+
         """
         opt = {
             "ocm_addon_id": ocm_addon_id,
             "ocm_cluster_id": ocm_cluster_id,
             "ocm_url": ocm_url,
             "ocm_refresh_token": ocm_refresh_token,
+            "ocm_addon_params": ocm_addon_params,
             "wait_for_ready_state": wait_for_ready_state,
         }
         return PlaybookRun("ocm_install_addon", opt)


### PR DESCRIPTION
OSDE2E addon test tweaks

- on integration will not install RHODS.
- Updated addon deployment to use the new `nvidia-gpu-addon`.
- Added ability to pass addon parameters for install
- updated README with new ocm_addon install param `ocm_addon_params`