### PR TITLE
OCM addon cleanup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -894,14 +894,12 @@ OCM addons
         run_toolbox.py ocm_addon install - Installs an OCM addon
     
     SYNOPSIS
-        run_toolbox.py ocm_addon install OCM_REFRESH_TOKEN OCM_CLUSTER_ID OCM_URL OCM_ADDON_ID <flags>
+        run_toolbox.py ocm_addon install OCM_CLUSTER_ID OCM_URL OCM_ADDON_ID <flags>
     
     DESCRIPTION
         Installs an OCM addon
     
     POSITIONAL ARGUMENTS
-        OCM_REFRESH_TOKEN
-            For OCM login auth
         OCM_CLUSTER_ID
             Cluster ID from OCM's POV
         OCM_URL
@@ -928,14 +926,12 @@ OCM addons
         run_toolbox.py ocm_addon remove - Removes an OCM addon
     
     SYNOPSIS
-        run_toolbox.py ocm_addon remove OCM_REFRESH_TOKEN OCM_CLUSTER_ID OCM_URL OCM_ADDON_ID <flags>
+        run_toolbox.py ocm_addon remove OCM_CLUSTER_ID OCM_URL OCM_ADDON_ID <flags>
     
     DESCRIPTION
         Removes an OCM addon
     
     POSITIONAL ARGUMENTS
-        OCM_REFRESH_TOKEN
-            For OCM login auth
         OCM_CLUSTER_ID
             Cluster ID from OCM's POV
         OCM_URL

--- a/README.rst
+++ b/README.rst
@@ -919,3 +919,34 @@ OCM addons
     
     NOTES
         You can also use flags syntax for POSITIONAL ARGUMENTS
+
+``./run_toolbox.py ocm_addon remove``
+
+.. code-block:: text
+
+    NAME
+        run_toolbox.py ocm_addon remove - Removes an OCM addon
+    
+    SYNOPSIS
+        run_toolbox.py ocm_addon remove OCM_REFRESH_TOKEN OCM_CLUSTER_ID OCM_URL OCM_ADDON_ID <flags>
+    
+    DESCRIPTION
+        Removes an OCM addon
+    
+    POSITIONAL ARGUMENTS
+        OCM_REFRESH_TOKEN
+            For OCM login auth
+        OCM_CLUSTER_ID
+            Cluster ID from OCM's POV
+        OCM_URL
+            Used to determine environment
+        OCM_ADDON_ID
+            the addon id to install. (such as `managed-odh`, `gpu-operator-certified-addon` etc.)
+    
+    FLAGS
+        --wait_until_removed=WAIT_UNTIL_REMOVED
+            Default: False
+            Optional. If true will cause the role to wait until addon is removed from cluster. (Can time out)
+    
+    NOTES
+        You can also use flags syntax for POSITIONAL ARGUMENTS

--- a/playbooks/ocm_remove_addon.yml
+++ b/playbooks/ocm_remove_addon.yml
@@ -1,0 +1,7 @@
+---
+- name: Remove an OCM addon
+  hosts: localhost
+  connection: local
+  gather_facts: true
+  roles:
+    - role: ocm_remove_addon

--- a/roles/ocm_install_addon/meta/main.yaml
+++ b/roles/ocm_install_addon/meta/main.yaml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: ocm_pre_checks

--- a/roles/ocm_install_addon/tasks/main.yml
+++ b/roles/ocm_install_addon/tasks/main.yml
@@ -1,59 +1,11 @@
 ---
-- name: Fail if ocm_refresh_token is undefined
-  fail: msg="Bailing out. This play requires ocm_refresh_token"
-  when: ocm_refresh_token is undefined
-
 - name: Fail if ocm_addon_id is undefined
   fail: msg="Bailing out. This play requires 'ocm_addon_id'"
   when: ocm_addon_id is undefined
 
-- name: Fail if ocm_url is undefined
-  fail: msg="Bailing out. This play requires 'ocm_url'"
-  when: ocm_url is undefined
-
-- name: Fail if ocm_cluster_id is undefined
-  fail: msg="Bailing out. This play requires 'ocm_cluster_id'"
-  when: ocm_cluster_id is undefined
-
-- name: Debug cluster and url (env)
-  debug:
-    msg: "ocm_cluster_id: {{ ocm_cluster_id  }}, ocm_url: {{ ocm_url }}"
-
 - name: ocm addon id
   debug:
     msg: "ocm addon id to install: {{ ocm_addon_id  }}"
-
-- name: Check if ocm is available
-  command: ocm version
-  register: ocm_version
-  changed_when: false
-  failed_when: false
-
-- name: Fail if ocm is not available
-  fail: msg="ocm version command returned with a non 0 code"
-  when: ocm_version.rc|int != 0
-
-- name: Login to ocm
-  command: "ocm login --token={{ ocm_refresh_token }} --url={{ ocm_url }}"
-  no_log: true
-  register: ocm_login_cmd
-  changed_when: false
-
-- name: Check ocm whoami
-  command: ocm whoami
-  register: ocm_whoami
-  changed_when: false
-  failed_when: false
-
-- name: Fail if ocm is not logged in
-  fail: msg="ocm whoami failed with return code {{ ocm_whoami.rc  }}"
-  when: ocm_whoami.rc|int != 0
-
-- name: ocm whoami
-  debug:
-    msg: "ocm whoami: {{ ocm_whoami.stdout  }}"
-  changed_when: false
-  failed_when: false
 
 - name: Check if addon is already installed
   shell: 

--- a/roles/ocm_install_addon/vars/main.yaml
+++ b/roles/ocm_install_addon/vars/main.yaml
@@ -1,2 +1,3 @@
+---
 wait_for_ready_state: false
 ocm_addon_params: []

--- a/roles/ocm_pre_checks/tasks/main.yml
+++ b/roles/ocm_pre_checks/tasks/main.yml
@@ -1,0 +1,48 @@
+---
+- name: Fail if ocm_refresh_token is undefined
+  fail: msg="Bailing out. This play requires ocm_refresh_token"
+  when: ocm_refresh_token is undefined
+
+- name: Fail if ocm_url is undefined
+  fail: msg="Bailing out. This play requires 'ocm_url'"
+  when: ocm_url is undefined
+
+- name: Fail if ocm_cluster_id is undefined
+  fail: msg="Bailing out. This play requires 'ocm_cluster_id'"
+  when: ocm_cluster_id is undefined
+
+- name: Debug cluster and url (env)
+  debug:
+    msg: "ocm_cluster_id: {{ ocm_cluster_id  }}, ocm_url: {{ ocm_url }}"
+
+- name: Check if ocm is available
+  command: ocm version
+  register: ocm_version
+  changed_when: false
+  failed_when: false
+
+- name: Fail if ocm is not available
+  fail: msg="ocm version command returned with a non 0 code"
+  when: ocm_version.rc|int != 0
+
+- name: Login to ocm
+  command: "ocm login --token={{ ocm_refresh_token }} --url={{ ocm_url }}"
+  no_log: true
+  register: ocm_login_cmd
+  changed_when: false
+
+- name: Check ocm whoami
+  command: ocm whoami
+  register: ocm_whoami
+  changed_when: false
+  failed_when: false
+
+- name: Fail if ocm is not logged in
+  fail: msg="ocm whoami failed with return code {{ ocm_whoami.rc  }}"
+  when: ocm_whoami.rc|int != 0
+
+- name: ocm whoami
+  debug:
+    msg: "ocm whoami: {{ ocm_whoami.stdout  }}"
+  changed_when: false
+  failed_when: false

--- a/roles/ocm_pre_checks/tasks/main.yml
+++ b/roles/ocm_pre_checks/tasks/main.yml
@@ -1,8 +1,4 @@
 ---
-- name: Fail if ocm_refresh_token is undefined
-  fail: msg="Bailing out. This play requires ocm_refresh_token"
-  when: ocm_refresh_token is undefined
-
 - name: Fail if ocm_url is undefined
   fail: msg="Bailing out. This play requires 'ocm_url'"
   when: ocm_url is undefined
@@ -24,12 +20,6 @@
 - name: Fail if ocm is not available
   fail: msg="ocm version command returned with a non 0 code"
   when: ocm_version.rc|int != 0
-
-- name: Login to ocm
-  command: "ocm login --token={{ ocm_refresh_token }} --url={{ ocm_url }}"
-  no_log: true
-  register: ocm_login_cmd
-  changed_when: false
 
 - name: Check ocm whoami
   command: ocm whoami

--- a/roles/ocm_remove_addon/meta/main.yaml
+++ b/roles/ocm_remove_addon/meta/main.yaml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: ocm_pre_checks

--- a/roles/ocm_remove_addon/tasks/main.yml
+++ b/roles/ocm_remove_addon/tasks/main.yml
@@ -1,0 +1,59 @@
+---
+- name: Fail if ocm_addon_id is undefined
+  fail: msg="Bailing out. This play requires 'ocm_addon_id'"
+  when: ocm_addon_id is undefined
+
+- name: ocm addon id
+  debug:
+    msg: "ocm addon id to install: {{ ocm_addon_id  }}"
+
+- name: Check if addon is already installed
+  shell: 
+    cmd: "ocm get /api/clusters_mgmt/v1/clusters/{{ ocm_cluster_id }}/addons/{{ ocm_addon_id  }} 2>&1 | jq -r '.kind'"
+  register: ocm_addon_precheck
+  failed_when: false
+  changed_when: false
+
+- name: Set addon current state
+  set_fact:
+    addon_installed: "{{ ocm_addon_precheck.stdout != 'Error' }}"
+  changed_when: false
+
+- name: Is addon installed
+  debug: 
+    msg: "Addon installed in cluster: {{ addon_installed }}"
+
+- name: "Remove addon {{ ocm_addon_id  }} via ocm"
+  shell: 
+    cmd: "ocm delete /api/clusters_mgmt/v1/clusters/{{ ocm_cluster_id  }}/addons/{{ ocm_addon_id  }} 2>&1 | jq -r '.kind'"
+  register: addon_remove_command
+  failed_when: false
+  when: addon_installed
+
+- name: Fail if response kind is Error
+  fail: 
+    msg: "response kind: {{ addon_remove_command.stdout }}"
+  when: 
+    - addon_remove_command is defined
+    - addon_remove_command.stdout is defined
+    - addon_remove_command.stdout == 'Error'
+
+- name: Debug wait_until_removed
+  debug: msg="Wait for ready state={{ wait_until_removed }}"
+
+- name: Poll addon state until reached desired state
+  shell:
+    cmd: "ocm get /api/clusters_mgmt/v1/clusters/{{ ocm_cluster_id }}/addons/{{ ocm_addon_id  }} 2>&1 | jq -r '.state'"
+  register: addon_state_result
+  changed_when: false
+  retries: 8
+  delay: 600
+  until: | 
+    (addon_state_result.stdout == 'deleting' and not wait_until_removed) or
+    (addon_state_result.stdout == '')
+  failed_when: |
+    (addon_state_result.stdout == 'installing') or
+    (addon_state_result.stdout == 'failed')
+
+- name: Polling end debug info
+  debug: msg="AddinId={{ ocm_addon_id }}, Wait until removed={{ wait_until_removed }}, Current addon state={{ addon_state_result.stdout }}"

--- a/roles/ocm_remove_addon/vars/main.yaml
+++ b/roles/ocm_remove_addon/vars/main.yaml
@@ -1,0 +1,2 @@
+---
+wait_until_removed: false

--- a/testing/osde2e/gpu-addon.sh
+++ b/testing/osde2e/gpu-addon.sh
@@ -26,6 +26,7 @@ source $THIS_DIR/../prow/gpu-operator.sh source
 
 function exit_and_abort() {
     echo "====== Test failed. Aborting."
+    cleanup_addons
     must_gather
     tar_artifacts
     exit 1
@@ -118,6 +119,16 @@ function tar_artifacts() {
     echo "====== Archive Done."
 }
 
+function cleanup_addons() {
+    echo "====== Cleaning up addons"
+    echo ""
+    echo "====== Removing RHODS..."
+    run_test "ocm_addon remove --ocm_addon_id=managed-odh --ocm_refresh_token=${OCM_REFRESH_TOKEN} --ocm_url=${OCM_ENV} --ocm_cluster_id=${CLUSTER_ID}  --wait_until_removed=True"
+    echo "====== Removing NVIDIA GPU Add-on..."
+    run_test "ocm_addon remove --ocm_addon_id=nvidia-gpu-addon --ocm_refresh_token=${OCM_REFRESH_TOKEN} --ocm_url=${OCM_ENV} --ocm_cluster_id=${CLUSTER_ID}  --wait_until_removed=True"
+    echo "====== Cleanup Done"
+}
+
 echo "====== Starting OSDE2E tests..."
 
 echo "Using ARTIFACT_DIR=$ARTIFACT_DIR."
@@ -155,6 +166,7 @@ echo "====== Operator found."
 echo "====== Running burn test for $((BURN_RUNTIME_SEC/60)) minutes ..."
 run_test "gpu_operator run_gpu_burn --runtime=${BURN_RUNTIME_SEC}"
 
+cleanup_addons
 must_gather
 tar_artifacts
 echo "====== Finished all jobs."

--- a/testing/osde2e/gpu-addon.sh
+++ b/testing/osde2e/gpu-addon.sh
@@ -148,7 +148,7 @@ ocm login --token=${OCM_REFRESH_TOKEN} --url=${OCM_ENV}
 # OSDE2E env specific workarounds
 ################
 
-if [[ ${OCM_ENV} == "integration" ]]; then
+if [[ ${OCM_ENV} == "int" ]]; then # integration
     echo "====== Skipping RHODS install"
 else
     echo "====== Installing RHODS"

--- a/testing/osde2e/gpu-addon.sh
+++ b/testing/osde2e/gpu-addon.sh
@@ -123,9 +123,9 @@ function cleanup_addons() {
     echo "====== Cleaning up addons"
     echo ""
     echo "====== Removing RHODS..."
-    run_test "ocm_addon remove --ocm_addon_id=managed-odh --ocm_refresh_token=${OCM_REFRESH_TOKEN} --ocm_url=${OCM_ENV} --ocm_cluster_id=${CLUSTER_ID}  --wait_until_removed=True"
+    run_test "ocm_addon remove --ocm_addon_id=managed-odh --ocm_url=${OCM_ENV} --ocm_cluster_id=${CLUSTER_ID}  --wait_until_removed=True"
     echo "====== Removing NVIDIA GPU Add-on..."
-    run_test "ocm_addon remove --ocm_addon_id=nvidia-gpu-addon --ocm_refresh_token=${OCM_REFRESH_TOKEN} --ocm_url=${OCM_ENV} --ocm_cluster_id=${CLUSTER_ID}  --wait_until_removed=True"
+    run_test "ocm_addon remove --ocm_addon_id=nvidia-gpu-addon --ocm_url=${OCM_ENV} --ocm_cluster_id=${CLUSTER_ID}  --wait_until_removed=True"
     echo "====== Cleanup Done"
 }
 
@@ -141,6 +141,8 @@ echo "OCM_ENV=${OCM_ENV:-}"
 OCM_REFRESH_TOKEN=$(oc get secrets ci-secrets -n osde2e-ci-secrets -o json | jq -r '.data|.["ocm-token-refresh"]' | base64 -d)
 echo "OCM_REFRESH_TOKEN=$(echo ${OCM_REFRESH_TOKEN} | cut -c1-6)...."
 
+ocm login --token=${OCM_REFRESH_TOKEN} --url=${OCM_ENV}
+
 
 ################
 # OSDE2E env specific workarounds
@@ -150,13 +152,13 @@ if [[ ${OCM_ENV} == "integration" ]]; then
     echo "====== Skipping RHODS install"
 else
     echo "====== Installing RHODS"
-    run_test "ocm_addon install --ocm_addon_id=managed-odh --ocm_refresh_token=${OCM_REFRESH_TOKEN} --ocm_url=${OCM_ENV} --ocm_cluster_id=${CLUSTER_ID} --ocm_addon_params='[{"id":"notification-email","value":"sdayan@redhat.com"}]' --wait_for_ready_state=True"
+    run_test "ocm_addon install --ocm_addon_id=managed-odh --ocm_url=${OCM_ENV} --ocm_cluster_id=${CLUSTER_ID} --ocm_addon_params='[{"id":"notification-email","value":"sdayan@redhat.com"}]' --wait_for_ready_state=True"
 fi
 
 ##### End - Should be removed and updated once RHODS is not required.
 
 echo "===== Installing GPU AddOn"
-run_test "ocm_addon install --ocm_addon_id=nvidia-gpu-addon --ocm_refresh_token=${OCM_REFRESH_TOKEN} --ocm_url=${OCM_ENV} --ocm_cluster_id=${CLUSTER_ID}"
+run_test "ocm_addon install --ocm_addon_id=nvidia-gpu-addon --ocm_url=${OCM_ENV} --ocm_cluster_id=${CLUSTER_ID}"
 
 
 echo "====== Waiting for gpu-operator..."

--- a/toolbox/ocm_addon.py
+++ b/toolbox/ocm_addon.py
@@ -32,3 +32,25 @@ class OCMAddon:
         }
         return PlaybookRun("ocm_install_addon", opt)
 
+    @staticmethod
+    def remove(ocm_refresh_token, ocm_cluster_id, ocm_url, ocm_addon_id, wait_until_removed=False):
+        """
+        Removes an OCM addon
+
+        Args:
+            ocm_refresh_token: For OCM login auth
+            ocm_cluster_id: Cluster ID from OCM's POV
+            ocm_url: Used to determine environment
+            ocm_addon_id: the addon id to install. (such as `managed-odh`, `gpu-operator-certified-addon` etc.)
+            wait_until_removed: Optional. If true will cause the role to wait until addon is removed from cluster. (Can time out)
+
+        """
+        opt = {
+            "ocm_addon_id": ocm_addon_id,
+            "ocm_cluster_id": ocm_cluster_id,
+            "ocm_url": ocm_url,
+            "ocm_refresh_token": ocm_refresh_token,
+            "wait_until_removed": wait_until_removed,
+        }
+        return PlaybookRun("ocm_remove_addon", opt)
+

--- a/toolbox/ocm_addon.py
+++ b/toolbox/ocm_addon.py
@@ -9,12 +9,11 @@ class OCMAddon:
     Commands for managing OCM addons
     """
     @staticmethod
-    def install(ocm_refresh_token, ocm_cluster_id, ocm_url, ocm_addon_id, ocm_addon_params=[], wait_for_ready_state=False):
+    def install(ocm_cluster_id, ocm_url, ocm_addon_id, ocm_addon_params=[], wait_for_ready_state=False):
         """
         Installs an OCM addon
 
         Args:
-            ocm_refresh_token: For OCM login auth
             ocm_cluster_id: Cluster ID from OCM's POV
             ocm_url: Used to determine environment
             ocm_addon_id: the addon id to install. (such as `managed-odh`, `gpu-operator-certified-addon` etc.)
@@ -26,19 +25,17 @@ class OCMAddon:
             "ocm_addon_id": ocm_addon_id,
             "ocm_cluster_id": ocm_cluster_id,
             "ocm_url": ocm_url,
-            "ocm_refresh_token": ocm_refresh_token,
             "ocm_addon_params": ocm_addon_params,
             "wait_for_ready_state": wait_for_ready_state,
         }
         return PlaybookRun("ocm_install_addon", opt)
 
     @staticmethod
-    def remove(ocm_refresh_token, ocm_cluster_id, ocm_url, ocm_addon_id, wait_until_removed=False):
+    def remove(ocm_cluster_id, ocm_url, ocm_addon_id, wait_until_removed=False):
         """
         Removes an OCM addon
 
         Args:
-            ocm_refresh_token: For OCM login auth
             ocm_cluster_id: Cluster ID from OCM's POV
             ocm_url: Used to determine environment
             ocm_addon_id: the addon id to install. (such as `managed-odh`, `gpu-operator-certified-addon` etc.)
@@ -49,7 +46,6 @@ class OCMAddon:
             "ocm_addon_id": ocm_addon_id,
             "ocm_cluster_id": ocm_cluster_id,
             "ocm_url": ocm_url,
-            "ocm_refresh_token": ocm_refresh_token,
             "wait_until_removed": wait_until_removed,
         }
         return PlaybookRun("ocm_remove_addon", opt)


### PR DESCRIPTION
This PR addresses add-on cleanup after osde2e tests.

- New role for add-on removal.
- OSDE2E script update and fixes.
- Fix potential secret leak by moving ocm login outside of the playbooks.


/cc @fabiendupont 
/cc @mresvanis 