### PR TITLE
OSDE2E: make sure RHODS is installed only on prod

### DIFF
--- a/testing/osde2e/gpu-addon.sh
+++ b/testing/osde2e/gpu-addon.sh
@@ -138,7 +138,7 @@ ocm login --token=${OCM_REFRESH_TOKEN} --url=${OCM_ENV}
 # OSDE2E env specific workarounds
 ################
 
-if [[ ${OCM_ENV} == "int" ]]; then # integration
+if [[ ${OCM_ENV} != "prod" ]]; then # (int)egration / (stage)ing
     echo "====== Skipping RHODS install"
 else
     echo "====== Installing RHODS"


### PR DESCRIPTION
This PR changes the condition for installing RHODS before this add-on. 
RHODS will not be installed on staging/integration.