### PR TITLE
nfd_operator_deploy_custom_commit: use the same golang version as in the NFD-operator repo

### DIFF
--- a/roles/nfd_operator_deploy_custom_commit/files/operator_image_builder_script.yml
+++ b/roles/nfd_operator_deploy_custom_commit/files/operator_image_builder_script.yml
@@ -31,7 +31,7 @@ data:
 
     podman pull docker.io/library/golang:1.16.3-buster
     podman pull registry.access.redhat.com/ubi8/ubi:latest
-    sed -i 's|FROM registry.ci.openshift.org/ocp/builder:rhel-.*-golang-\(.*\)-openshift-.* AS|FROM docker.io/library/golang:\1 AS|' Dockerfile
+    sed -i 's|FROM registry.ci.openshift.org/ocp/builder:rhel-.*-golang-\(.*\)-openshift-.* [Aa][sS]|FROM docker.io/library/golang:\1 AS|' Dockerfile
     sed -i '10s|.*|FROM registry.access.redhat.com/ubi8/ubi|' Dockerfile
 
     IMAGE_NAME="nfd-operator-ci:latest"

--- a/roles/nfd_operator_deploy_custom_commit/files/operator_image_builder_script.yml
+++ b/roles/nfd_operator_deploy_custom_commit/files/operator_image_builder_script.yml
@@ -31,7 +31,7 @@ data:
 
     podman pull docker.io/library/golang:1.16.3-buster
     podman pull registry.access.redhat.com/ubi8/ubi:latest
-    sed -i '2s|.*|FROM docker.io/library/golang:1.16.3-buster as builder|' Dockerfile
+    sed -i 's|FROM registry.ci.openshift.org/ocp/builder:rhel-.*-golang-\(.*\)-openshift-.* AS|FROM docker.io/library/golang:\1 AS|' Dockerfile
     sed -i '10s|.*|FROM registry.access.redhat.com/ubi8/ubi|' Dockerfile
 
     IMAGE_NAME="nfd-operator-ci:latest"


### PR DESCRIPTION
This PR fixes the testing of NFD-operator master.

Was cherry-picked from :
https://github.com/openshift-psap/ci-artifacts/pull/347
https://github.com/openshift-psap/ci-artifacts/pull/349

Thanks @kpouget !