### PR TITLE
Osde2e: Wait for NFD labels before testing GPU

### DIFF
--- a/testing/osde2e/gpu-addon.sh
+++ b/testing/osde2e/gpu-addon.sh
@@ -151,6 +151,12 @@ echo "===== Installing GPU AddOn"
 run_test "ocm_addon install --ocm_addon_id=nvidia-gpu-addon --ocm_url=${OCM_ENV} --ocm_cluster_id=${CLUSTER_ID} --wait_for_ready_state=True"
 
 
+# Wait for NFD labels
+echo "====== Waiting for NFD labels..."
+run_test "nfd wait_labels"
+echo "====== NFD labels found."
+
+
 echo "====== Waiting for gpu-operator..."
 run_test "gpu_operator wait_deployment"
 echo "====== Operator found."


### PR DESCRIPTION
Since the gpu add-on is installing NFD, we should wait until the NFD
labels appears. 
Then we can proceed to our operator tests/validations.

By not changing the roles themselves and adding this as a "step" in the osde2e script, we have same roles testing gpu-operator regardless if it was deployed via the add-on or not. 
