### PR TITLE
Follow redirects for mirror.openshift.com

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -24,7 +24,7 @@ RUN yum install -y \
 # Install dependencies: `oc`
 ARG OCP_CLI_VERSION=latest
 ARG OCP_CLI_URL=https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/${OCP_CLI_VERSION}/openshift-client-linux.tar.gz
-RUN curl ${OCP_CLI_URL} | tar xfz - -C /usr/local/bin oc
+RUN curl -L ${OCP_CLI_URL} | tar xfz - -C /usr/local/bin oc
 
 # Install dependencies: `ocm`
 ARG OCM_CLI_VERSION=v0.1.60


### PR DESCRIPTION
This PR adds the [curl](https://curl.se/docs/manpage.html) `-L` (`--location`) flag, in order to enable following redirects, for requests originating from the CI worker IP pool to [mirror.openshift.com](https://mirror.openshift.com/pub/). Such requests are now redirected to S3 buckets for cost saving.

Signed-off-by: Michail Resvanis <mresvani@redhat.com>