### PR TITLE
Fix ImageStream apiVersion not including the API group

### DIFF
--- a/roles/gpu_operator_bundle_from_commit/files/operator_ci_utils.yml
+++ b/roles/gpu_operator_bundle_from_commit/files/operator_ci_utils.yml
@@ -7,7 +7,7 @@ metadata:
 spec: {}
 ---
 kind: ImageStream
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 metadata:
   name: gpu-operator-ci-utils
   namespace: gpu-operator-ci-utils

--- a/roles/gpu_operator_bundle_from_commit/files/operator_imagestream.yml
+++ b/roles/gpu_operator_bundle_from_commit/files/operator_imagestream.yml
@@ -1,5 +1,5 @@
 kind: ImageStream
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 metadata:
   name: gpu-operator-ci
   namespace: gpu-operator-ci

--- a/roles/local-ci_deploy/files/imagestream.yml
+++ b/roles/local-ci_deploy/files/imagestream.yml
@@ -1,5 +1,5 @@
 kind: ImageStream
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 metadata:
   name: ci-artifacts
   namespace: ci-artifacts

--- a/roles/local-ci_deploy/files/operator_ci_utils.yml
+++ b/roles/local-ci_deploy/files/operator_ci_utils.yml
@@ -7,7 +7,7 @@ metadata:
 spec: {}
 ---
 kind: ImageStream
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 metadata:
   name: gpu-operator-ci-utils
   namespace: gpu-operator-ci-utils

--- a/roles/nfd_operator_deploy_custom_commit/files/operator_imagestream.yml
+++ b/roles/nfd_operator_deploy_custom_commit/files/operator_imagestream.yml
@@ -1,6 +1,6 @@
 ---
 kind: ImageStream
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 metadata:
   name: nfd-operator-ci
   namespace: nfd-operator-ci
@@ -9,7 +9,7 @@ metadata:
 spec: {}
 ---
 kind: ImageStream
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 metadata:
   name: nfd-operator-ci-utils
   namespace: nfd-operator-ci-utils


### PR DESCRIPTION
This PR fixes the [ImageStream](https://docs.openshift.com/container-platform/4.11/openshift_images/image-streams-manage.html) objects' `apiVersion` field not including the appropriate API group, i.e. `image.openshift.io/v1`.

Signed-off-by: Michail Resvanis <mresvani@redhat.com>