### PR TITLE
Fix GPU operator bundle build helper not including all dev tools

### DIFF
--- a/roles/cluster_wait_for_alert/tasks/main.yml
+++ b/roles/cluster_wait_for_alert/tasks/main.yml
@@ -19,7 +19,7 @@
   shell: |
     set -e;
     set -o pipefail;
-    curl -s -k -H "Authorization: Bearer $(oc -n openshift-monitoring sa get-token prometheus-k8s)" https://{{ alert_manager_route_cmd.stdout }}/api/v1/alerts \
+    curl -s -k -H "Authorization: Bearer $(oc -n openshift-monitoring sa new-token prometheus-k8s)" https://{{ alert_manager_route_cmd.stdout }}/api/v1/alerts \
        | jq . > "{{ alert_filename }}"; \
     grep -q '"alertname": "{{ cluster_wait_for_alert_name }}"' "{{ alert_filename }}" # could be improved with 'jq' and a stronger json inspection ...
   register: wait_for_alert

--- a/roles/gpu_operator_bundle_from_commit/files/operator_bundle_image_builder_script.sh
+++ b/roles/gpu_operator_bundle_from_commit/files/operator_bundle_image_builder_script.sh
@@ -29,7 +29,7 @@ CONTAINER_FILE=./docker/bundle.Dockerfile
 
 CONTEXT_LOCATION="."
 
-CSV_FILE=bundle/manifests/gpu-operator.clusterserviceversion.yaml
+CSV_FILE=bundle/manifests/gpu-operator-certified.clusterserviceversion.yaml
 
 (echo "{ \"auths\": " ; cat /var/run/secrets/openshift.io/push/.dockercfg ; echo "}") > /tmp/.dockercfg_local
 LOCAL_AUTH="--tls-verify=false --authfile /tmp/.dockercfg_local"

--- a/roles/gpu_operator_bundle_from_commit/files/operator_helper_image_builder.yml
+++ b/roles/gpu_operator_bundle_from_commit/files/operator_helper_image_builder.yml
@@ -44,6 +44,18 @@ spec:
           dnf clean all && \
           rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 
+      # The following layer is not part of the original file
+      RUN dnf -y install git \
+            jq \
+            make \
+            podman \
+            python3 python3-devel python3-pip python3-setuptools \
+            --exclude container-selinux \
+            --enablerepo=updates-testing && \
+          dnf clean all && \
+          python3 -m pip install --no-cache-dir --upgrade setuptools pip wheel && \
+          python3 -m pip install --no-cache-dir yq
+
       # Define uid/gid ranges for our user https://github.com/containers/buildah/issues/3053
       RUN useradd build && \
           echo -e "build:1:999\npodman:1001:64535" > /etc/subuid && \

--- a/roles/gpu_operator_bundle_from_commit/templates/build_driver.yml.j2
+++ b/roles/gpu_operator_bundle_from_commit/templates/build_driver.yml.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1
+apiVersion: build.openshift.io/v1
 kind: BuildConfig
 metadata:
   labels:

--- a/roles/gpu_operator_bundle_from_commit/templates/build_validator.yml.j2
+++ b/roles/gpu_operator_bundle_from_commit/templates/build_validator.yml.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1
+apiVersion: build.openshift.io/v1
 kind: BuildConfig
 metadata:
   labels:


### PR DESCRIPTION
This PR adds `git`, `make`, `jq` and `yq` in the GPU operator bundle builder helper container, as they are required by the bash scripts that build the operator image from its `master` branch and the respective operator bundle.

Signed-off-by: Michail Resvanis <mresvani@redhat.com>