### PR TITLE
Fix trying to remove non-empty dir

### DIFF
--- a/testing/prow/gpu-operator.sh
+++ b/testing/prow/gpu-operator.sh
@@ -155,7 +155,7 @@ collect_must_gather() {
                 eval $ENV
 
                 echo "Copying must-gather results to $ARTIFACT_EXTRA_LOGS_DIR ..."
-                cp -r "$TMP_DIR"/* "$ARTIFACT_EXTRA_LOGS_DIR"
+                mv "$TMP_DIR"/* "$ARTIFACT_EXTRA_LOGS_DIR"
 
                 rmdir "$TMP_DIR"
             fi


### PR DESCRIPTION
Temp must-gather directory must be empty before `rmdir`.
Some minor improvements like enclosing vars in double-quotes.