### PR TITLE
Revert wrapping toolbox command in quotes

### DIFF
--- a/testing/osde2e/gpu-addon.sh
+++ b/testing/osde2e/gpu-addon.sh
@@ -63,7 +63,7 @@ function run_test() {
 $JUNIT_HEADER_TEMPLATE
 EOF
 
-    /usr/bin/time -o ${RUNTIME_FILE} ./run_toolbox.py "${TARGET}" > $OUTPUT_FILE
+    /usr/bin/time -o ${RUNTIME_FILE} ./run_toolbox.py ${TARGET} > $OUTPUT_FILE
 
     trap_run_test
 }


### PR DESCRIPTION
Double quotes break the script causing 

```
./run_toolbox.py "ocm_addon install ... "
ERROR: Could not consume arg: ocm_addon install ...
Usage: run_toolbox.py <command>
  available commands:    benchmarking | cluster | entitlement | gpu_operator |
                         local_ci | nfd | nfd_operator | ocm_addon | repo | sro

For detailed information on this command, run:
  run_toolbox.py --help
```