### PR TITLE
Fix GPU operator master tests on OCP 4.12

### DIFF
--- a/roles/gpu_operator_bundle_from_commit/tasks/build_operator.yml
+++ b/roles/gpu_operator_bundle_from_commit/tasks/build_operator.yml
@@ -34,6 +34,9 @@
   - name: Delete the operator image builder pod, if any
     command: oc delete -f "{{ artifact_extra_logs_dir }}/operator-image-builder-pod.yml" --ignore-not-found=true
 
+  - name: Name the namespace privileged
+    command: oc adm policy add-scc-to-user privileged -z default -n gpu-operator-ci
+
   - name: Apply the operator image builder pod manifest
     command:
       oc apply -f "{{ artifact_extra_logs_dir }}/operator-image-builder-pod.yml"

--- a/roles/gpu_operator_deploy_from_operatorhub/tasks/deploy_from_bundle.yml
+++ b/roles/gpu_operator_deploy_from_operatorhub/tasks/deploy_from_bundle.yml
@@ -25,6 +25,9 @@
   command:
     oc create namespace {{ gpu_operator_operator_namespace }}
 
+- name: Name the namespace privileged
+  command: oc adm policy add-scc-to-user privileged -z default -n {{ gpu_operator_operator_namespace }}
+
 - name: Deploy the GPU Operator from the bundle
   command:
     operator-sdk run bundle --timeout=5m


### PR DESCRIPTION
This PR fixes the GPU operator master branch tests on OCP 4.12, by adjusting the pod security admission controller levels to `privileged` for the namespace in which the operator and bundle images are built.

The [Pod Security admission controller](https://kubernetes.io/docs/concepts/security/pod-security-admission/) enforces restrictions at the namespace level. Since we need `privileged` to build images from the GPU operator master branch, we have added the required security context to the `default` service account of that namespace. The OCP [label synchronization](https://github.com/openshift/enhancements/blob/master/enhancements/authentication/pod-security-admission-autolabeling.md#pod-security-admission-label-synchronization) takes care of adding the appropriate PSA labels to the namespace.

Signed-off-by: Michail Resvanis <mresvani@redhat.com>