### PR TITLE
Fix NFD operator deployment on OCP 4.12

### DIFF
--- a/roles/cluster_deploy_operator/tasks/main.yml
+++ b/roles/cluster_deploy_operator/tasks/main.yml
@@ -198,11 +198,6 @@
     command:
       oc create -f "{{ artifact_extra_logs_dir }}/000_namespace.yml"
 
-  - name: Mark the namespace for monitoring, if requested
-    when: cluster_deploy_operator_namespace_monitoring | bool
-    command:
-      oc label ns/{{ cluster_deploy_operator_namespace }} openshift.io/cluster-monitoring=true
-
 - name: Create the OperatorGroup for deploying in a dedicated namespace
   when: not cluster_deploy_operator_all_namespaces | bool
   block:

--- a/roles/cluster_deploy_operator/templates/namespace.yml.j2
+++ b/roles/cluster_deploy_operator/templates/namespace.yml.j2
@@ -3,8 +3,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ cluster_deploy_operator_namespace }}
-{% if cluster_deploy_operator_namespace_monitoring | bool %}
-  label:
-    openshift.io/cluster-monitoring: true
-{% endif %}
+  labels:
+    security.openshift.io/scc.podSecurityLabelSync: "true"
+    openshift.io/cluster-monitoring: "true"
 

--- a/roles/entitlement_test_wait_deployment/files/entitlement-tester_entrypoint.yml
+++ b/roles/entitlement_test_wait_deployment/files/entitlement-tester_entrypoint.yml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: entitlement-tester-entrypoint
-  namespace: default
+  namespace: entitlement-tester
 data:
   entrypoint.sh: |-
     #!/bin/bash

--- a/roles/entitlement_test_wait_deployment/files/entitlement-tester_pod.yml
+++ b/roles/entitlement_test_wait_deployment/files/entitlement-tester_pod.yml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
  name: entitlement-tester
- namespace: default
+ namespace: entitlement-tester
 spec:
   containers:
   - name: entitlement-tester

--- a/roles/entitlement_test_wait_deployment/tasks/main.yml
+++ b/roles/entitlement_test_wait_deployment/tasks/main.yml
@@ -15,6 +15,14 @@
       set -o errexit;
       set -o pipefail;
 
+      oc create namespace  entitlement-tester --dry-run=client -o yaml | oc apply -f -
+      oc label namespace entitlement-tester \
+        security.openshift.io/scc.podSecurityLabelSync=false \
+        pod-security.kubernetes.io/enforce=privileged \
+        pod-security.kubernetes.io/audit=privileged \
+        pod-security.kubernetes.io/warn=privileged \
+        --overwrite
+
       oc apply -f "{{ entitlement_tester_entrypoint }}"
       oc delete -f "{{ entitlement_tester_pod }}" --ignore-not-found=true;
       oc create -f "{{ entitlement_tester_pod }}";
@@ -23,7 +31,7 @@
       CMD="oc get pod/entitlement-tester
                 -o custom-columns=:.status.phase
                 --no-headers
-                -n default
+                -n entitlement-tester
                 ";
       while true; do
           state=$($CMD)
@@ -57,7 +65,7 @@
 
   - name: Store the description of the test Pod (debug)
     shell:
-      oc describe pod/entitlement-tester -n default
+      oc describe pod/entitlement-tester -n entitlement-tester
          > {{ artifact_extra_logs_dir }}/entitlement-test.pod.descr
     failed_when: false
 
@@ -67,12 +75,12 @@
   always:
   - name: Store the test Pod logs (debug)
     shell:
-      oc logs pod/entitlement-tester -n default
+      oc logs pod/entitlement-tester -n entitlement-tester
          > {{ artifact_extra_logs_dir }}/entitlement-test.pod.log
     failed_when: false
 
   - name: Show the test Pod logs (debug)
-    command: oc logs pod/entitlement-tester -n default
+    command: oc logs pod/entitlement-tester -n entitlement-tester
     when: _entitlement_testwait_called_from_inspect == "yes" or entitlement_wait.rc != 0
     failed_when: false
 

--- a/roles/gpu_operator_deploy_from_operatorhub/files/010_namespace.yml
+++ b/roles/gpu_operator_deploy_from_operatorhub/files/010_namespace.yml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: gpu-operator-resources
-  label:
+  labels:
     openshift.io/cluster-monitoring: "true"

--- a/roles/gpu_operator_run_gpu-burn/tasks/main.yml
+++ b/roles/gpu_operator_run_gpu-burn/tasks/main.yml
@@ -18,12 +18,22 @@
   register: gpu_burn_gpu_nodes
   failed_when: gpu_burn_gpu_nodes.stdout == ""
 
+- name: Create the gpu-burn namespace and label it as privileged
+  shell: |
+    oc create namespace gpu-burn --dry-run=client -o yaml | oc apply -f -
+    oc label namespace gpu-burn \
+      security.openshift.io/scc.podSecurityLabelSync=false \
+      pod-security.kubernetes.io/enforce=privileged \
+      pod-security.kubernetes.io/audit=privileged \
+      pod-security.kubernetes.io/warn=privileged \
+      --overwrite
+
 # Store the configmap into a file, for easy reproduction from artifacts
 - name: Create the entrypoint ConfigMap file
   shell:
     oc create configmap gpu-burn-entrypoint
        --from-file=entrypoint.sh={{ gpu_burn_entrypoint }}
-       -n default
+       -n gpu-burn
        --dry-run=client
        -oyaml
        > {{ artifact_extra_logs_dir }}/000_configmap_gpu-burn_entrypoint.yml
@@ -37,7 +47,7 @@
   shell:
     oc create configmap gpu-burn-src
        --from-file={{ gpu_burn_src_dir }}
-       -n default
+       -n gpu-burn
        --dry-run=client
        -oyaml
        > {{ artifact_extra_logs_dir }}/000_configmap_gpu-burn_src.yml
@@ -46,7 +56,7 @@
   command: oc apply -f {{ artifact_extra_logs_dir }}/000_configmap_gpu-burn_src.yml
 
 - name: Delete possibly stalled GPU burn Pods
-  command: oc --ignore-not-found=true delete pod/gpu-burn-{{ item }} -n default
+  command: oc --ignore-not-found=true delete pod/gpu-burn-{{ item }} -n gpu-burn
   with_items: "{{ gpu_burn_gpu_nodes.stdout_lines }}"
   failed_when: false
 
@@ -74,7 +84,7 @@
     loop: "{{ gpu_burn_gpu_nodes.stdout_lines }}"
     command:
       oc get pod/gpu-burn-{{ item }}
-         -n default
+         -n gpu-burn
          -o custom-columns=:.status.phase
          --no-headers
     register: gpu_burn_wait
@@ -86,35 +96,35 @@
   - name: Ensure that no GPU was faulty
     loop: "{{ gpu_burn_gpu_nodes.stdout_lines }}"
     shell:
-      oc logs pod/gpu-burn-{{ item }} -n default | grep FAULTY
+      oc logs pod/gpu-burn-{{ item }} -n gpu-burn | grep FAULTY
     register: gpu_burn_test_faulty
     failed_when: gpu_burn_test_faulty.rc == 0
 
   always:
   - name: Save the logs of the GPU burn Pods
-    shell: oc logs pod/gpu-burn-{{ item }} -n default | grep -o "[^$(printf '\r')]*$"
+    shell: oc logs pod/gpu-burn-{{ item }} -n gpu-burn | grep -o "[^$(printf '\r')]*$"
     with_items: "{{ gpu_burn_gpu_nodes.stdout_lines }}"
     failed_when: false
 
   - name: Save the description of the GPU burn Pods
-    shell: oc describe pod/gpu-burn-{{ item }} -n default > {{ artifact_extra_logs_dir }}/gpu_burn.{{ item }}.description.txt
+    shell: oc describe pod/gpu-burn-{{ item }} -n gpu-burn > {{ artifact_extra_logs_dir }}/gpu_burn.{{ item }}.description.txt
     with_items: "{{ gpu_burn_gpu_nodes.stdout_lines }}"
     failed_when: false
 
   - name: Save the full logs of the GPU burn Pods
-    shell: oc logs pod/gpu-burn-{{ item }} -n default > {{ artifact_extra_logs_dir }}/gpu_burn.{{ item }}.log
+    shell: oc logs pod/gpu-burn-{{ item }} -n gpu-burn > {{ artifact_extra_logs_dir }}/gpu_burn.{{ item }}.log
     with_items: "{{ gpu_burn_gpu_nodes.stdout_lines }}"
     failed_when: false
 
   - name: Cleanup the GPU burn Pods
-    command: oc --ignore-not-found=true delete pod/gpu-burn-{{ item }} -n default
+    command: oc --ignore-not-found=true delete pod/gpu-burn-{{ item }} -n gpu-burn
     with_items: "{{ gpu_burn_gpu_nodes.stdout_lines }}"
     failed_when: false
 
   - name: Delete the entrypoint ConfigMap
-    command: oc --ignore-not-found=true delete configmap gpu-burn-entrypoint -n default
+    command: oc --ignore-not-found=true delete configmap gpu-burn-entrypoint -n gpu-burn
     failed_when: false
 
   - name: Delete the src ConfigMap
-    command: oc --ignore-not-found=true delete configmap src -n default
+    command: oc --ignore-not-found=true delete configmap src -n gpu-burn
     failed_when: false

--- a/roles/gpu_operator_run_gpu-burn/templates/gpu_burn_pod.yml
+++ b/roles/gpu_operator_run_gpu-burn/templates/gpu_burn_pod.yml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: gpu-burn
   name: gpu-burn-{{ gpu_node_name }}
-  namespace: default
+  namespace: gpu-burn
 spec:
   restartPolicy: Never
   # force the name of the node in which this pod should run

--- a/roles/nfd_operator_deploy_custom_commit/files/operator_helper_image_builder.yml
+++ b/roles/nfd_operator_deploy_custom_commit/files/operator_helper_image_builder.yml
@@ -15,7 +15,7 @@ spec:
     type: Dockerfile
     dockerfile: |
       # git/Dockerfile
-      # https://github.com/containers/buildah/blob/master/contrib/buildahimage/upstream/Dockerfile
+      # https://github.com/containers/buildah/blob/main/contrib/buildahimage/upstream/Containerfile
       #
       # Build a Buildah container image from the latest
       # upstream version of Buildah on GitHub.
@@ -25,57 +25,66 @@ spec:
       # The containers created by this image also come with a
       # Buildah development environment in /root/buildah.
       #
-      FROM registry.fedoraproject.org/fedora:35
-      ENV GOPATH=/root/buildah
+      FROM registry.fedoraproject.org/fedora:36
 
-      # Install the software required to build Buildah.
-      # Then create a directory and clone from the Buildah
-      # GitHub repository, make and install Buildah
-      # to the container.
-      # Finally remove the buildah directory and a few other packages
-      # that are needed for building but not running Buildah
-      RUN useradd build \
-          && yum -y update \
-          && yum -y reinstall shadow-utils \
-          && yum -y install --enablerepo=updates-testing \
+      # Don't include container-selinux and remove
+      # directories used by dnf that are just taking
+      # up space.  The latest buildah + deps. come from
+      # https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/
+      # TODO: rpm --setcaps... needed due to Fedora (base) image builds
+      #       being (maybe still?) affected by
+      #       https://bugzilla.redhat.com/show_bug.cgi?id=1995337#c3
+      RUN dnf -y update && \
+          rpm --setcaps shadow-utils 2>/dev/null && \
+          dnf -y install 'dnf-command(copr)' --enablerepo=updates-testing && \
+          dnf -y copr enable rhcontainerbot/podman-next && \
+          dnf -y install buildah fuse-overlayfs \
+              --exclude container-selinux \
+              --enablerepo=updates-testing && \
+          dnf clean all && \
+          rm -rf /var/cache /var/log/dnf* /var/log/yum.*
+
+      # The following layer is not part of the original file
+      RUN dnf -y install git \
+            jq \
             make \
-            golang \
             podman \
-            bats \
-            btrfs-progs-devel \
-            device-mapper-devel \
-            glib2-devel \
-            gpgme-devel \
-            libassuan-devel \
-            libseccomp-devel \
-            git \
-            bzip2 \
-            xz \
-            go \
-            go-md2man \
-            runc \
-            fuse-overlayfs \
-            fuse3 \
-            containers-common \
-          && mkdir /root/buildah \
-          && git clone https://github.com/containers/buildah /root/buildah/src/github.com/containers/buildah \
-          && cd /root/buildah/src/github.com/containers/buildah \
-          && make \
-          && make install \
-          && rm -rf /root/buildah/* \
-          && yum -y remove bats golang go-md2man \
-          && yum clean all
+            python3 python3-devel python3-pip python3-setuptools \
+            --exclude container-selinux \
+            --enablerepo=updates-testing && \
+          dnf clean all && \
+          python3 -m pip install --no-cache-dir --upgrade setuptools pip wheel && \
+          python3 -m pip install --no-cache-dir yq
 
-      ADD https://raw.githubusercontent.com/containers/buildah/master/contrib/buildahimage/stable/containers.conf /etc/containers/
+      # Define uid/gid ranges for our user https://github.com/containers/buildah/issues/3053
+      RUN useradd build && \
+          echo -e "build:1:999\npodman:1001:64535" > /etc/subuid && \
+          echo -e "build:1:999\npodman:1001:64535" > /etc/subgid && \
+          mkdir -p /home/build/.local/share/containers && \
+          chown -R build:build /home/build
 
-      # Adjust storage.conf to enable Fuse storage.
-      RUN chmod 644 /etc/containers/containers.conf \
-        && sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' /etc/containers/storage.conf
-      RUN mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers /var/lib/shared/vfs-images /var/lib/shared/vfs-layers \
-        && touch /var/lib/shared/overlay-images/images.lock \
-        && touch /var/lib/shared/overlay-layers/layers.lock \
-        && touch /var/lib/shared/vfs-images/images.lock \
-        && touch /var/lib/shared/vfs-layers/layers.lock
+      ADD https://raw.githubusercontent.com/containers/buildah/main/contrib/buildahimage/stable/containers.conf /etc/containers/
+
+      # Copy & modify the defaults to provide reference if runtime changes needed.
+      # Changes here are required for running with fuse-overlay storage inside container.
+      RUN sed -e 's|^#mount_program|mount_program|g' \
+              -e '/additionalimage.*/a "/var/lib/shared",' \
+              -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' \
+              /usr/share/containers/storage.conf \
+              > /etc/containers/storage.conf && \
+          chmod 644 /etc/containers/storage.conf
+
+      RUN mkdir -p /var/lib/shared/overlay-images \
+                   /var/lib/shared/overlay-layers \
+                   /var/lib/shared/vfs-images \
+                   /var/lib/shared/vfs-layers && \
+          touch /var/lib/shared/overlay-images/images.lock && \
+          touch /var/lib/shared/overlay-layers/layers.lock && \
+          touch /var/lib/shared/vfs-images/images.lock && \
+          touch /var/lib/shared/vfs-layers/layers.lock
+
+      VOLUME /var/lib/containers
+      VOLUME /home/build/.local/share/containers
 
       # Set an environment variable to default to chroot isolation for RUN
       # instructions and "buildah run".


### PR DESCRIPTION
The Pod Security admission controller enforces restrictions at the namespace level. Since we need `privileged` to run the NFD pods in the NFD operator namespace and the latter is prefixed by `openshift-`,  we have added the required sync label.

- https://kubernetes.io/docs/concepts/security/pod-security-admission/
- https://github.com/openshift/cluster-policy-controller/blob/master/pkg/psalabelsyncer/podsecurity_label_sync_controller.go#L335-L341

Signed-off-by: Michail Resvanis <mresvani@redhat.com>