### PR TITLE
`oc` version pinning in Dockerfile

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -22,7 +22,7 @@ RUN yum install -y \
 
 
 # Install dependencies: `oc`
-ARG OCP_CLI_VERSION=latest
+ARG OCP_CLI_VERSION=4.11.12
 ARG OCP_CLI_URL=https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/${OCP_CLI_VERSION}/openshift-client-linux.tar.gz
 RUN curl -L ${OCP_CLI_URL} | tar xfz - -C /usr/local/bin oc
 


### PR DESCRIPTION
This is to avoid issues with `oc` commands updating/changing under our feet.
We can always update the version manually, this will result in a better CI integration.